### PR TITLE
Third rewrite

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "cSpell.words": [
     "AAGUID",
+    "KEYID",
     "hmac"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "cSpell.words": [
+    "AAGUID",
+    "hmac"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,9 @@
 {
   "cSpell.words": [
     "AAGUID",
+    "FIPS",
     "KEYID",
+    "NIST",
     "hmac"
   ]
 }

--- a/fido-2-derivation-nicolas.md
+++ b/fido-2-derivation-nicolas.md
@@ -42,9 +42,9 @@ Construct:
 
 - version = 1 = 0x01
 - `optional_metadata_from_seed_generator = byte[]` // arbitrary length byte array
-- raw_credential_id = `H(K1 || userId)`
-- tag = `H(K2 || raw_credential_id || rpIdHash || optional_metadata_from_seed_generator)`
-- P256 seed (secret scalar) = `H(K3 || tag)`: tag is used as we don't have the RP in the raw ID
+- credential_id_field = `H(K, || "credential_id_field" || userId || hash)`
+- tag = `H(K, 2 || "credential_mac" || rpIdHash || optional_metadata_from_seed_generator)`
+- P256 seed (secret scalar) = `H(K, "p256_secret_key" || rp_id || tag)`: tag is used as we don't have the RP in the raw ID
 
 If cryptographically necessary, use HMAC(K, -) instead of H(K || -) as appropriate, I don't think there are any length extension attacks applicable here.
 

--- a/fido-2-derivation-nicolas.md
+++ b/fido-2-derivation-nicolas.md
@@ -56,7 +56,7 @@ We should specify (independent of used crypto library) whether P256 seed is inte
 
 Outputs (sent to RP):
 
-- Credential ID: version || tag || raw_credential_id || seed_generator_metadata
+- Credential ID: version || raw_credential_id || seed_generator_metadata || tag
 - P256 public key
 
 
@@ -67,7 +67,7 @@ Note that the signatures the authenticator makes are over clientData (which cont
 
 ### GetAssertion
 
-Inputs: credentiald, rpIdHash
+Inputs: credentialId, rpIdHash
 
 Steps:
 

--- a/fido-2-derivation-nicolas.md
+++ b/fido-2-derivation-nicolas.md
@@ -41,8 +41,11 @@ Inputs: rpIdHash (32B, e.g. H(example.com)), userId (RP-assigned and password-ve
 Construct:
 
 - version = 1 = 0x01
+- seed_generator_type = byte (0 or byte absent => unspecified, 1 => DiceKeys)
+- seed_generators_state = byte[] (0 to n bytes for n <= some constraint set by authenticator)
+- seed_generator_metadata = seed_generator_type || seed_generators_state
 - raw_credential_id = `H(K1 || userId)`
-- tag = `H(K2 || raw_credential_id || rpIdHash)`
+- tag = `H(K2 || raw_credential_id || rpIdHash || seed_generator_metadata)`
 - P256 seed (secret scalar) = `H(K3 || tag)`: tag is used as we don't have the RP in the raw ID
 
 If cryptographically necessary, use HMAC(K, -) instead of H(K || -) as appropriate, I don't think there are any length extension attacks applicable here.
@@ -53,7 +56,7 @@ We should specify (independent of used crypto library) whether P256 seed is inte
 
 Outputs (sent to RP):
 
-- Credential ID: `[version, raw_credential_id, tag]` (1 + 32 + 32 = 65B)
+- Credential ID: version || tag || raw_credential_id || seed_generator_metadata
 - P256 public key
 
 

--- a/fido-2-derivation-nicolas.md
+++ b/fido-2-derivation-nicolas.md
@@ -41,11 +41,9 @@ Inputs: rpIdHash (32B, e.g. H(example.com)), userId (RP-assigned and password-ve
 Construct:
 
 - version = 1 = 0x01
-- seed_generator_type = byte (0 or byte absent => unspecified, 1 => DiceKeys)
-- seed_generators_state = byte[] (0 to n bytes for n <= some constraint set by authenticator)
-- seed_generator_metadata = seed_generator_type || seed_generators_state
+- `optional_metadata_from_seed_generator = byte[]` // arbitrary length byte array
 - raw_credential_id = `H(K1 || userId)`
-- tag = `H(K2 || raw_credential_id || rpIdHash || seed_generator_metadata)`
+- tag = `H(K2 || raw_credential_id || rpIdHash || optional_metadata_from_seed_generator)`
 - P256 seed (secret scalar) = `H(K3 || tag)`: tag is used as we don't have the RP in the raw ID
 
 If cryptographically necessary, use HMAC(K, -) instead of H(K || -) as appropriate, I don't think there are any length extension attacks applicable here.
@@ -56,7 +54,7 @@ We should specify (independent of used crypto library) whether P256 seed is inte
 
 Outputs (sent to RP):
 
-- Credential ID: version || raw_credential_id || seed_generator_metadata || tag
+- Credential ID: version || raw_credential_id || optional_metadata_from_seed_generator || tag
 - P256 public key
 
 

--- a/fido2-key-derivation.md
+++ b/fido2-key-derivation.md
@@ -10,6 +10,7 @@ Only use cryptographic primitives from the [FIDO Authenticator Allowed Cryptogra
   - AES-256 from [Section 3.1](https://fidoalliance.org/specs/fido-security-requirements-v1.2-2018/fido-authenticator-allowed-cryptography-list-v1.0-wd-20180629.html#confidentiality-algorithms), where the 256 indicates the key size (AES has a foxed 128-bit block size).
   - SHA-256 from [Section 3.2](https://fidoalliance.org/specs/fido-security-requirements-v1.2-2018/fido-authenticator-allowed-cryptography-list-v1.0-wd-20180629.html#hashing-algorithms).
 
+
 ## Algorithm
 
 First, generate a fixed-length 256-bit key identifier _i_ from the arbitrary-length KEYID field.

--- a/key-derivation.md
+++ b/key-derivation.md
@@ -1,60 +1,58 @@
-# Creating WebAuthN/FIDO2 Credentials Deterministically from Seeds
+# Seeded WebAuthN Authenticator Specification
 
-This specification defines how create credentials for WebAuthN/FIDO2
-from a 256-bit seed key _seedKey_.
+This specification defines how create credentials for [WebAuthN]((https://www.w3.org/TR/webauthn))/FIDO2 from a 256-bit seed key (**`seedKey`**) and to authenticate with those credentials.
 
-On calls to [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred), an authenticator will use _s_ to generate a [Credential ID](https://www.w3.org/TR/webauthn/#credential-id) and public/private key pair for authentication.
+Specifically, on calls to [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred), an authenticator will use the `seedKey` to generate a [Credential ID](https://www.w3.org/TR/webauthn/#credential-id) and public/private authentication key pair, sending the Credential ID and public key to the relying party.
 
-On calls to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion), an authenticator will use _s_ to validate that
-the Credential Id was generated from _s_, for use by the relying party making
-the request, and to and re-derive the public/private key pair needed to authenticate on calls to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion). 
+On calls to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion), an authenticator will use the `seedKey` to validate that the Credential ID was generated from `seedKey` for use by the requesting relying party, and then to re-derive the private key needed to authenticate.
 
 
-## Terminology
+## Open issues
 
-### Hash function H
+ - Choose a keyed hash function `H(key, preimage)` -- re-ask Joseph Bonneau
+ - Can we use a function such that `H(key, preimage) = H(key || preimage)` -- ask Joseph Bonneau
+ - Are strings represented b"" null terminated? - Stuart is asking Nicolas
+  - Do we need a modular reduction operation as part of the derivation of the secret key?
 
+## Inputs
 
-We will assume a keyed hash function H(_key_, _value_).
+### The secret seed key (**`seedKey`**)
 
-**TO DO**
-Determine which to use.
+**`seedKey`** is a fixed-length 256-bit (32 byte) secret key written into an authenticator to give it an replicable identity. It is so named as it seeds all other cryptographic operations.
+This secret key is the only information an authenticator should require to authenticate via the [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion) operation, even if a different authenticator used the same seed to create the Credential ID and accompanying public key during the [`authenticatorMakeCredential`](https://www.w3.org/TR/webauthn/#op-make-cred) operation.
 
+### External state stored with the `seedKey` (**`extState`**)
 
-### Relying Party ID (`rpId`)
+**`extState`** is an optional field of 0 and 256 bytes and is written to the authenticator along with the `seedKey`.  It is stored in plaintext within the Credential ID so that the relying party will keep a copy of it and share it with any party that attempts to authenticate. The field may contain information used to locate or re-generate the `seedKey` if an authenticator needs to be replaced.  Since this field is stored in plaintext with the relying party, it should not be used without careful consideration of the risks of sharing the information therein with the relying party, and the potential to make Credential IDs linkable.  (The degree of this risk depends on whether the value is quite common among multiple users or unique to each user.)
 
-We use `rpId` to indicate the [relying party identifier](https://www.w3.org/TR/webauthn/#relying-party-identifier) passed to [`authenticatorMakeCredential`](https://www.w3.org/TR/webauthn/#op-make-cred) via the the [`id`](https://www.w3.org/TR/webauthn/#dom-publickeycredentialrpentity-id) field of the [`rpEntity`](https://www.w3.org/TR/webauthn/#dictionary-pkcredentialentity) parameter, and passed to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion) via the  `rpId` parameter. 
+### Relying Party ID (**`rpId`**)
 
-### User ID (`userId`)
+**`rpId`** is the [relying party identifier](https://www.w3.org/TR/webauthn/#relying-party-identifier) passed to [`authenticatorMakeCredential`](https://www.w3.org/TR/webauthn/#op-make-cred) via the the [`id`](https://www.w3.org/TR/webauthn/#dom-publickeycredentialrpentity-id) field of the [`rpEntity`](https://www.w3.org/TR/webauthn/#dictionary-pkcredentialentity) parameter, and passed to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion) via the  `rpId` parameter. 
 
-We use `userId` to indicate the user identifier passed to [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred) via the [`id`](https://www.w3.org/TR/webauthn/#dom-publickeycredentialrpentity-id) field of the [`userEntity`](https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialuserentity) parameter.
-(It is not available on calls to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion).)
+## Implementing [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred)
 
+### Generating a [Credential ID](https://www.w3.org/TR/webauthn/#credential-id) (**`credentialId`**)
 
-## The Credential ID format
-
-Credential IDs are concatenations of four fields, three of fixed length and an optional field (`extState`)  of variable length.
-
-```
-    version || uniqueId || extState || credentialMac
-```
-
-**`version`** is a single byte and should be set to `1`.
-
-If [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion) encounters a Credential ID with the `version` byte set to `0` or to a number greater than the authenticator supports, it should fail.  (FIXME -- describe proper failure response.)
-
-
-**`uniqueId`** is a 32-byte value that ensures the Credential Id meets the WebAuthN's requirement of having at least 100 bits of entropy to ensure uniqueness.
-
-Some authenticators may want to have a deterministic mode in which an observer that knows the seed _s_ can verify that the authenticator is behaving correctly.  The recommended deterministic algorithm for generating the uniqueId field is:
+Generate a Credential ID by concatenating four fields.
 
 ```
-    H(seedKey, b"uniqueId" || rpId || userId || hash)
+credentialId = version || uniqueId || extState || credentialMac
 ```
 
-where hash is the `hash` field of [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred).
+**`version`** is a single byte and should be set to 1 (`0x01`).
 
-**`extState`** is an optional byte array of length [0..256]. It can store external written to the authenticator along with the seed, and its inclusion in the Credential ID will ensure this information is stored by the relying party. One use of this field would be to store information needed to salt the seed or to identify which of the user's seeds was stored in the authenticator. If no `extState` is specified it is treated as being of zero length.  It's length can be calculated as the length of the credential ID minus 65 (the collective lengths of the one byte `version`, the 32-byte `uniqueId` and the 32-byte `credentialMac`).
+**`uniqueId`** is _any_ 32-byte value that ensures the Credential Id meets the WebAuthN's requirement of having at least 100 bits of entropy to ensure uniqueness.
+
+To support an optional deterministic mode, in which an observer that knows `seekKey` can verify that the authenticator generated the `credentialId` correctly, use the following formula for the `uniqueID`:
+
+```
+uniqueId = H(seedKey, b"uniqueId" || rpId || userId || hash)
+```
+
+where **`hash`** is a parameter passed to [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred) and **`userId`** is the [`id`](https://www.w3.org/TR/webauthn/#dom-publickeycredentialrpentity-id) field of the [`userEntity`](https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialuserentity) parameter.
+
+**`extState`** , defined [above](#Inputs) is an optional byte array of any length from 0 to 256 bytes, where the absence of the optional value is treated as a zero-length byte array.
+
 
 **`credentialMac`** is a message authentication code that ensures the Credential ID has not been modified since it was created by the authenticator.
 
@@ -62,44 +60,54 @@ where hash is the `hash` field of [authenticatorMakeCredential](https://www.w3.o
 credentialMac = H(seedKey, b"credentialMac" || rpId || version || uniqueId || extState)
 ```
 
-## Deriving ES256 the secret key
+### Deriving the ES256 public key
 
-The secret key is derived from the `seedKey`, the `rpId` (relying party identifier) which is passed to both [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred) and [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion), and the `credentialMac` field.
+Derive the private key **`es256SPrivateKey`**  from the `seedKey` on the authenticator, the `rpId` from the relying party, and the `credentialMac` field from the `credentialId` (which, as a MAC, effectively encapsulates the three other fields of `credentialId`.
 
 ```
-es256SecretKey = H(seedKey, b"es256SecretKey" || rpId || credentialMac)
+es256SPrivateKey = H(seedKey, b"es256SPrivateKey" || rpId || credentialMac)
 ```
 
-Nicolas had written
-> tag [now credentialMac] is used as we don't have the RP in the raw ID
-
-Stuart writes
-> But `rpId` is passed to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion), so it should be available when we need to re-derive the secret key.
+To derive the public key to send to return, use the existing deterministic algorithm for calculating ES public keys from private keys.
 
 
 ## Implementing [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion)
 
-Extract the four fields of the Credential ID.
+Decoding and validating credential Ids is part of step 3 of the WebAuthN specification for [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion).
+
+### Extracting the four fields of the `credentialId`
+
+Since the only variable length field is `extData`, its length can be calculated by subtracting the length of the other fields (65 bytes, the collective lengths of the one byte `version`, the 32-byte `uniqueId` and the 32-byte `credentialMac`) from the length of the Credential ID.
+
 ```
-// The first byte of es256SecretKey is the version
+// The first byte of credentialId is the version field
 version = CredentialId[0]
 
-// The unique ID is the next 32 bytes
-uniqueId = credentialId[1...32]
+// The next 32 bytes are the uniqueID field
+uniqueId = credentialId[1...32] // inclusive
 
-// The credentialMac is the last 32 bytes and extData is any bytes in between
-extData = credentialId[33...(credentialId.length -32)]
-credentialMac = credentialId[(credentialId.length -32)...credentialId.length]
+// The credentialMac is the last 32 bytes and extData is any remaining bytes before the credentialMac
+extData = credentialId[33...(credentialId.length - 33)] // [33...32] indicates a 0-length array
+credentialMac = credentialId[(credentialId.length - 32)...(credentialId.length - 1)]
 ```
 
-Continue only if `version == 1`.
-Otherwise, _FIXME_.
+### Validating the `credentialID`.
+
+If `version 1 != 1` terminate the processing of this Credential ID. If no valid Credential IDs are found, the list of credentials will be empty and step 6 of the [specification of `authenticatorGetAssertion`](https://www.w3.org/TR/webauthn/#op-get-assertion) dictates that the operation be terminated with a ["NotAllowedError"](https://heycam.github.io/webidl/#notallowederror).
+
+Next, recalculate the MAC so that we can verify the Credential ID has not been modified.
 
 ```
 recalculatedCredentialMac = H(seedKey, b"credentialMac" || rpId || version || uniqueId || extState)
 ```
 
-Continue only if `recalculatedCredentialMac == credentialMac`.
-Otherwise, _FIXME_.
+If `recalculatedCredentialMac != credentialMac`, terminate the processing of this Credential ID.  Again, if no valid Credential IIs are found, the list of credentials will be empty and step 6 of the [specification of `authenticatorGetAssertion`](https://www.w3.org/TR/webauthn/#op-get-assertion) dictates that the operation be terminated with a ["NotAllowedError"](https://heycam.github.io/webidl/#notallowederror).
 
-Recalculate `es256SecretKey` using the formula above.
+
+### Re-deriving the **`es256SPrivateKey`**
+
+Iff all steps of the above validation process succeed, use the same formula was was used above and authenticate with the secret key.
+
+```
+es256SPrivateKey = H(seedKey, b"es256SPrivateKey" || rpId || credentialMac)
+```

--- a/key-derivation.md
+++ b/key-derivation.md
@@ -39,7 +39,7 @@ credentialId = version || uniqueId || extState || credentialMac
 
 **`uniqueId`** is _any_ 32-byte value that ensures the Credential Id meets the WebAuthN's requirement of having at least 100 bits of entropy to ensure uniqueness.
 
-To support an optional deterministic mode, in which an observer that knows `seekKey` can verify that the authenticator generated the `credentialId` correctly, use the following formula for the `uniqueID`:
+To support an optional deterministic mode, in which an observer that knows `seekKey` can verify that the authenticator generated the `credentialId` correctly, one can use a deterministic formula such as the one below to calculate the `uniqueID`:
 
 ```
 uniqueId = SHA256HMAC( SHA256HMAC( seedKey, salt ) , rpId || userId || hash)

--- a/key-derivation.md
+++ b/key-derivation.md
@@ -42,7 +42,7 @@ credentialId = version || uniqueId || extState || credentialMac
 To support an optional deterministic mode, in which an observer that knows `seekKey` can verify that the authenticator generated the `credentialId` correctly, use the following formula for the `uniqueID`:
 
 ```
-uniqueId = SHA256HMAC( SHA245HMAC( seedKey, salt ) , rpId || userId || hash)
+uniqueId = SHA256HMAC( SHA256HMAC( seedKey, salt ) , rpId || userId || hash)
 ```
 
 where **`salt`** is any string of the implementers choosing and  **`hash`** is a parameter passed to [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred) and **`userId`** is the [`id`](https://www.w3.org/TR/webauthn/#dom-publickeycredentialrpentity-id) field of the [`userEntity`](https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialuserentity) parameter.

--- a/key-derivation.md
+++ b/key-derivation.md
@@ -98,6 +98,20 @@ es256SPrivateKey = H(seedKey, b"es256SPrivateKey" || rpId || credentialMac)
 To derive the public key to send to return, use the existing deterministic algorithm for calculating ES public keys from private keys.
 
 
+
+### Setting the [Signature Counter](https://www.w3.org/TR/webauthn/#signature-counter)
+
+The [W3C's WebAuthN specification](https://www.w3.org/TR/webauthn/#signature-counter) states that "Authenticators SHOULD implement a signature counter feature" and that "the signature counter's purpose is to aid Relying Parties in detecting cloned authenticators."  The W3C uses "SHOULD" as defined by [IETF RFC 2119](https://www.ietf.org/rfc/rfc2119.txt), which states
+
+> This word, or the adjective "RECOMMENDED", mean that there may exist valid reasons in particular circumstances to ignore a particular item, but the full implications must be understood and carefully weighed before choosing a different course.
+
+No reason could be more valid than to support users who choose purchase an authenticator that can be cloned because they want the ability to clone it.  Authenticators following our standard MUST use the approach specified in [WebAuthN Specification Section 6.2.3](https://www.w3.org/TR/webauthn/#op-make-cred), item 10, option 3 to set no signature counter.
+
+> **no signature counter**
+>
+> let the signature counter value for the new credential be constant at zero.
+
+
 ## Implementing [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion)
 
 Decoding and validating credential Ids is part of step 3 of the WebAuthN specification for [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion).

--- a/key-derivation.md
+++ b/key-derivation.md
@@ -9,37 +9,10 @@ On calls to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-a
 
 ## Open issues
 
- - Choose a keyed hash function `H(key, preimage)` -- re-ask Joseph Bonneau
  - Are strings represented b"" null terminated? - Stuart is asking Nicolas
   - Do we need a modular reduction operation as part of the derivation of the secret key?
 
 ## Prerequisites
-
-Assume some keyed has function `H(key, use, preImage)`, which `use` is a value that indicates what we are using the hash function to generate.  Two possible ways to implement `H` would be
-
-```
-// well-defined common, but most resource hungry
-H(key, use, preImage) = SHA_256_HMAC(key + use, preimage)
-```
-
-```
-// A similar construction using CBC-MAC, using
-// the last blocks 2 AES blocks as 256-bit hash
-// length can be a 128 bit block
-// Less computation overhead
-H(key, use, preImage) = CBC-MAC(key, iv=0, length || use(preimage) || preImage)
-```
-
-
-```
-// Minimal number of AES block calculations
-// useIndex = 1, 2, 3...
-// (iv big endian?)
-H(key, use, preImage) = CBC-MAC(key, iv = useIndex * 2^64 + length(preimage), preImage)
-```
-
-
-
 
 ## Inputs
 
@@ -73,7 +46,7 @@ credentialId = version || uniqueId || extState || credentialMac
 To support an optional deterministic mode, in which an observer that knows `seekKey` can verify that the authenticator generated the `credentialId` correctly, use the following formula for the `uniqueID`:
 
 ```
-uniqueId = H(seedKey, b"uniqueId", rpId || userId || hash)
+uniqueId = SHA256HMAC(seedKey, b"uniqueId" || rpId || userId || hash)
 ```
 
 where **`hash`** is a parameter passed to [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred) and **`userId`** is the [`id`](https://www.w3.org/TR/webauthn/#dom-publickeycredentialrpentity-id) field of the [`userEntity`](https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialuserentity) parameter.
@@ -84,7 +57,7 @@ where **`hash`** is a parameter passed to [authenticatorMakeCredential](https://
 **`credentialMac`** is a message authentication code that ensures the Credential ID has not been modified since it was created by the authenticator.
 
 ```
-credentialMac = H(seedKey, b"credentialMac", rpId || version || uniqueId || extState)
+credentialMac = SHA256HMAC(seedKey, b"credentialMac" || rpId || version || uniqueId || extState)
 ```
 
 ### Deriving the ES256 public key
@@ -92,7 +65,7 @@ credentialMac = H(seedKey, b"credentialMac", rpId || version || uniqueId || extS
 Derive the private key **`es256SPrivateKey`**  from the `seedKey` on the authenticator, the `rpId` from the relying party, and the `credentialMac` field from the `credentialId` (which, as a MAC, effectively encapsulates the three other fields of `credentialId`.
 
 ```
-es256SPrivateKey = H(seedKey, b"es256SPrivateKey" || rpId || credentialMac)
+es256SPrivateKey = SHA256HMAC(seedKey, b"es256SPrivateKey" || rpId || credentialMac)
 ```
 
 To derive the public key to send to return, use the existing deterministic algorithm for calculating ES public keys from private keys.
@@ -139,7 +112,7 @@ If `version 1 != 1` terminate the processing of this Credential ID. If no valid 
 Next, recalculate the MAC so that we can verify the Credential ID has not been modified.
 
 ```
-recalculatedCredentialMac = H(seedKey, b"credentialMac", || rpId || version || uniqueId || extState)
+recalculatedCredentialMac = SHA256HMAC(seedKey, b"credentialMac" || rpId || version || uniqueId || extState)
 ```
 
 If `recalculatedCredentialMac != credentialMac`, terminate the processing of this Credential ID.  Again, if no valid Credential IIs are found, the list of credentials will be empty and step 6 of the [specification of `authenticatorGetAssertion`](https://www.w3.org/TR/webauthn/#op-get-assertion) dictates that the operation be terminated with a ["NotAllowedError"](https://heycam.github.io/webidl/#notallowederror).
@@ -150,5 +123,5 @@ If `recalculatedCredentialMac != credentialMac`, terminate the processing of thi
 Iff all steps of the above validation process succeed, use the same formula was was used above and authenticate with the secret key.
 
 ```
-es256SPrivateKey = H(seedKey, b"es256SPrivateKey", rpId || credentialMac)
+es256SPrivateKey = SHA256HMAC(seedKey, b"es256SPrivateKey" || rpId || credentialMac)
 ```

--- a/key-derivation.md
+++ b/key-derivation.md
@@ -1,0 +1,105 @@
+# Creating WebAuthN/FIDO2 Credentials Deterministically from Seeds
+
+This specification defines how create credentials for WebAuthN/FIDO2
+from a 256-bit seed key _seedKey_.
+
+On calls to [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred), an authenticator will use _s_ to generate a [Credential ID](https://www.w3.org/TR/webauthn/#credential-id) and public/private key pair for authentication.
+
+On calls to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion), an authenticator will use _s_ to validate that
+the Credential Id was generated from _s_, for use by the relying party making
+the request, and to and re-derive the public/private key pair needed to authenticate on calls to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion). 
+
+
+## Terminology
+
+### Hash function H
+
+
+We will assume a keyed hash function H(_key_, _value_).
+
+**TO DO**
+Determine which to use.
+
+
+### Relying Party ID (`rpId`)
+
+We use `rpId` to indicate the [relying party identifier](https://www.w3.org/TR/webauthn/#relying-party-identifier) passed to [`authenticatorMakeCredential`](https://www.w3.org/TR/webauthn/#op-make-cred) via the the [`id`](https://www.w3.org/TR/webauthn/#dom-publickeycredentialrpentity-id) field of the [`rpEntity`](https://www.w3.org/TR/webauthn/#dictionary-pkcredentialentity) parameter, and passed to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion) via the  `rpId` parameter. 
+
+### User ID (`userId`)
+
+We use `userId` to indicate the user identifier passed to [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred) via the [`id`](https://www.w3.org/TR/webauthn/#dom-publickeycredentialrpentity-id) field of the [`userEntity`](https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialuserentity) parameter.
+(It is not available on calls to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion).)
+
+
+## The Credential ID format
+
+Credential IDs are concatenations of four fields, three of fixed length and an optional field (`extState`)  of variable length.
+
+```
+    version || uniqueId || extState || credentialMac
+```
+
+**`version`** is a single byte and should be set to `1`.
+
+If [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion) encounters a Credential ID with the `version` byte set to `0` or to a number greater than the authenticator supports, it should fail.  (FIXME -- describe proper failure response.)
+
+
+**`uniqueId`** is a 32-byte value that ensures the Credential Id meets the WebAuthN's requirement of having at least 100 bits of entropy to ensure uniqueness.
+
+Some authenticators may want to have a deterministic mode in which an observer that knows the seed _s_ can verify that the authenticator is behaving correctly.  The recommended deterministic algorithm for generating the uniqueId field is:
+
+```
+    H(seedKey, b"uniqueId" || rpId || userId || hash)
+```
+
+where hash is the `hash` field of [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred).
+
+**`extState`** is an optional byte array of length [0..256]. It can store external written to the authenticator along with the seed, and its inclusion in the Credential ID will ensure this information is stored by the relying party. One use of this field would be to store information needed to salt the seed or to identify which of the user's seeds was stored in the authenticator. If no `extState` is specified it is treated as being of zero length.  It's length can be calculated as the length of the credential ID minus 65 (the collective lengths of the one byte `version`, the 32-byte `uniqueId` and the 32-byte `credentialMac`).
+
+**`credentialMac`** is a message authentication code that ensures the Credential ID has not been modified since it was created by the authenticator.
+
+```
+credentialMac = H(seedKey, b"credentialMac" || rpId || version || uniqueId || extState)
+```
+
+## Deriving ES256 the secret key
+
+The secret key is derived from the `seedKey`, the `rpId` (relying party identifier) which is passed to both [authenticatorMakeCredential](https://www.w3.org/TR/webauthn/#op-make-cred) and [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion), and the `credentialMac` field.
+
+```
+es256SecretKey = H(seedKey, b"es256SecretKey" || rpId || credentialMac)
+```
+
+Nicolas had written
+> tag [now credentialMac] is used as we don't have the RP in the raw ID
+
+Stuart writes
+> But `rpId` is passed to [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion), so it should be available when we need to re-derive the secret key.
+
+
+## Implementing [authenticatorGetAssertion](https://www.w3.org/TR/webauthn/#op-get-assertion)
+
+Extract the four fields of the Credential ID.
+```
+// The first byte of es256SecretKey is the version
+version = CredentialId[0]
+
+// The unique ID is the next 32 bytes
+uniqueId = credentialId[1...32]
+
+// The credentialMac is the last 32 bytes and extData is any bytes in between
+extData = credentialId[33...(credentialId.length -32)]
+credentialMac = credentialId[(credentialId.length -32)...credentialId.length]
+```
+
+Continue only if `version == 1`.
+Otherwise, _FIXME_.
+
+```
+recalculatedCredentialMac = H(seedKey, b"credentialMac" || rpId || version || uniqueId || extState)
+```
+
+Continue only if `recalculatedCredentialMac == credentialMac`.
+Otherwise, _FIXME_.
+
+Recalculate `es256SecretKey` using the formula above.


### PR DESCRIPTION
I rewrote the spec (now key-derivation.md in this PR) to make it accessible to readers who are unfamiliar with the details of WebAuthN and FIDO2 and as I walked through everything carefully in detail.

The structure of credentialId hasn't changed, but a few things have.

 - All inputs are now named to better match WebAuthN and extensively documented with pointers to the WebAuthN spec.
 - There is no longer a need to derive subkeys from the seed, which should simplify both the spec and possibly the implementation.
 - There are fewer restrictions on how the 32 byte unique identifier within the credential ID is derived, as inspection revealed it has no impact on other authenticator's ability to authenticate with the same credential ID.
 - Per @nickray's request, I simplified the external seed state so that the spec is indifferent to how it uses its first byte
 - The specification now addresses which errors will result when validations fail.





